### PR TITLE
Navigation bar opacity

### DIFF
--- a/strabo/static/public_styles/about.css
+++ b/strabo/static/public_styles/about.css
@@ -23,7 +23,7 @@
 /* Header text */
 #page-header {
   padding: 1.3em;
-    padding-top: 4.428571429em;  /*20/14 */
+  padding-top: 4.428571429em;  /*20/14 */
 }
 
 /* Header text font */
@@ -92,6 +92,7 @@ h2 {
 .inline-img{
     padding: 1em;
 }
+
 @media (max-width: 470px) {
     /* if screen is too small, then make sure text does not go around
     the images and center the image */
@@ -100,6 +101,7 @@ h2 {
         text-align: center;
     }
 }
+
 .right-img{
   float: right;
 }

--- a/strabo/static/public_styles/header.css
+++ b/strabo/static/public_styles/header.css
@@ -52,7 +52,7 @@ span.icon-bar {
   background-color: #ffffff; 
 }
 
-
+/* Change the appearance of the navbar on mobile */
 @media (max-width: 767px){
   .navbar{
     /*background-color: rgba(66,44,30,0.7); /* #422C1E with opacity */
@@ -65,7 +65,7 @@ span.icon-bar {
     pointer-events: auto;
   }
   ul {
-    background: #422C1E;
+    background: rgba(66,44,30,0.9); /*#422C1E;*/
     pointer-events: auto;
   }
   li {
@@ -73,10 +73,5 @@ span.icon-bar {
     pointer-events: auto;
   }
 }
-
-
-
-
-
 
 

--- a/strabo/static/public_styles/header.css
+++ b/strabo/static/public_styles/header.css
@@ -11,15 +11,33 @@
 .navbar-brand {
   padding: 0em;
 }
-
 .navbar-brand>img {
   height: 100%;
   width: auto;
   padding-left: 0.857142857em; /* 12/14 */
 }
 
+/* Navbar Menu Items */
+.header .menu {
+  float: right;
+  list-style: none;
+  margin-top: 0em;
+}
+.menu > li {
+  display: inline;
+  padding-left: 1.428571429em; /* 20/14 */
+  padding-right: 1.428571429em;
+}
+.menu a {
+  color: #ffffd8;
+  font-family: 'Futura', sans-serif;
+  font-size: 1.428571429em;
+}
 
-
+ /* Hover background on navbar menu */
+.nav>li>a:focus, .nav>li>a:hover {
+    background-color: #583a28;
+}
 
 /* Toggle Button */
 .navbar-toggle {
@@ -30,7 +48,6 @@
   border: 0.071428571em solid #ffffff; 
   border-radius: 0.285712386em; /* 4/14 */
 }
-
 span.icon-bar {
   background-color: #ffffff; 
 }
@@ -38,27 +55,22 @@ span.icon-bar {
 
 
 
-/* Navbar Menu Items */
-.header .menu {
-  float: right;
-  list-style: none;
-  margin-top: 0em;
+@media (max-width: 767px){
+  .navbar{
+    background-color: rgba(66,44,30,0.5);
+  } 
+  .navbar-header {
+    background-color: rgba(66,44,30,1);
+  }
+
+  /*ul {
+    background: #422C1E;
+  }*/
 }
 
-.menu > li {
-  display: inline;
-  padding-left: 1.428571429em; /* 20/14 */
-  padding-right: 1.428571429em;
-}
 
-.menu a {
-  color: #ffffd8;
-  font-family: 'Futura', sans-serif;
-  font-weight: 300;
-  font-size: 1.428571429em;
-}
 
- /* Hover background on navbar menu */
-.nav>li>a:focus, .nav>li>a:hover {
-    background-color: #583a28;
-}
+
+
+
+

--- a/strabo/static/public_styles/header.css
+++ b/strabo/static/public_styles/header.css
@@ -2,29 +2,12 @@
 
 .navbar {
   background-color: #422C1E;
-  /* background-color: #006666; */
   border-bottom: 0.071428571em solid #2e1e15;
   opacity: 1;
   padding: 0.071428571em;
 }
-/*
-.navbar-header a {
-  float: left;
-  color: #006666;
-  font-family: 'Century Gothic','Lucida-Sans', sans-serif;
-  font-weight: 700;
-  font-size: 2.142857143em; /* 30/14
-} */
 
-.navbar-toggle {
-  position: relative;
-  float: right;
-  background-color: #422C1E;
-  background-image: none;
-  border: 0.071428571em solid #ffffff; /* #777;*/
-  border-radius: 0.285712386em; /* 4/14 */
-}
-
+/* Logo */
 .navbar-brand {
   padding: 0em;
 }
@@ -35,12 +18,27 @@
   padding-left: 0.857142857em; /* 12/14 */
 }
 
-span.icon-bar {
-  background-color: #ffffff; /* #777; */
+
+
+
+/* Toggle Button */
+.navbar-toggle {
+  position: relative;
+  float: right;
+  background-color: #422C1E;
+  background-image: none;
+  border: 0.071428571em solid #ffffff; 
+  border-radius: 0.285712386em; /* 4/14 */
 }
 
-/* Navbar Menu */
+span.icon-bar {
+  background-color: #ffffff; 
+}
 
+
+
+
+/* Navbar Menu Items */
 .header .menu {
   float: right;
   list-style: none;
@@ -60,9 +58,7 @@ span.icon-bar {
   font-size: 1.428571429em;
 }
 
- /* Change the color of the hover background on the navbar menu */
+ /* Hover background on navbar menu */
 .nav>li>a:focus, .nav>li>a:hover {
-    /* background-color: #ebf5e4; */ /* Leaving this commented out in case we want to change back */
-    /* background-color: #425e8a; */
     background-color: #583a28;
 }

--- a/strabo/static/public_styles/header.css
+++ b/strabo/static/public_styles/header.css
@@ -55,7 +55,7 @@ span.icon-bar {
 
 @media (max-width: 767px){
   .navbar{
-    background-color: rgba(66,44,30,0.5); /* #422C1E with 0.5 opacity */
+    background-color: rgba(66,44,30,0.7); /* #422C1E with opacity */
   } 
   .navbar-header {
     background-color: rgba(66,44,30,1); /* #422C1E */

--- a/strabo/static/public_styles/header.css
+++ b/strabo/static/public_styles/header.css
@@ -55,16 +55,22 @@ span.icon-bar {
 
 @media (max-width: 767px){
   .navbar{
-    background-color: rgba(66,44,30,0.7); /* #422C1E with opacity */
+    /*background-color: rgba(66,44,30,0.7); /* #422C1E with opacity */
+    background: transparent;
+    border: transparent;
+    pointer-events: none;
   } 
   .navbar-header {
-    background-color: rgba(66,44,30,1); /* #422C1E */
+    background-color: #422C1E;
+    pointer-events: auto;
   }
-  /*ul {
-    background: rgba(66,44,30,0.5);*/
+  ul {
+    background: #422C1E;
+    pointer-events: auto;
   }
   li {
     text-decoration: underline;
+    pointer-events: auto;
   }
 }
 

--- a/strabo/static/public_styles/header.css
+++ b/strabo/static/public_styles/header.css
@@ -53,19 +53,19 @@ span.icon-bar {
 }
 
 
-
-
 @media (max-width: 767px){
   .navbar{
-    background-color: rgba(66,44,30,0.5);
+    background-color: rgba(66,44,30,0.5); /* #422C1E with 0.5 opacity */
   } 
   .navbar-header {
-    background-color: rgba(66,44,30,1);
+    background-color: rgba(66,44,30,1); /* #422C1E */
   }
-
   /*ul {
-    background: #422C1E;
-  }*/
+    background: rgba(66,44,30,0.5);*/
+  }
+  li {
+    text-decoration: underline;
+  }
 }
 
 

--- a/strabo/templates/public/header.html
+++ b/strabo/templates/public/header.html
@@ -3,7 +3,7 @@
 <nav class="navbar navbar-fixed-top" role="navigation">
   <div class="container-fluid">
 
-    <div class="navbar-header"> 
+    <!--div class="navbar-header"> 
 
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
@@ -11,11 +11,16 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
        </button>
+    </div-->
 
-       <a class="navbar-brand" href="/">
-       <img src="/static/leafylogo.png" />
-       </a>
-    </div>
+    <a class="navbar-brand" href="/">
+       <img src="/static/leafylogo.png">
+    </a>
+    
+
+    <nav class="cbp-spmenu cbp-spmenu-vertical cbp-spmenu-right" id="cbp-spmenu-s2">
+    </nav>
+
 
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav menu">

--- a/strabo/templates/public/header.html
+++ b/strabo/templates/public/header.html
@@ -3,26 +3,20 @@
 <nav class="navbar navbar-fixed-top" role="navigation">
   <div class="container-fluid">
 
-    <!--div class="navbar-header"> 
-
+    <div class="navbar-header"> 
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
        </button>
-    </div-->
 
-    <a class="navbar-brand" href="/">
-       <img src="/static/leafylogo.png">
-    </a>
-    
+        <a class="navbar-brand" href="/">
+        <img src="/static/leafylogo.png">
+        </a>
+    </div>
 
-    <nav class="cbp-spmenu cbp-spmenu-vertical cbp-spmenu-right" id="cbp-spmenu-s2">
-    </nav>
-
-
-    <div class="collapse navbar-collapse">
+    <div class="collapse navbar-collapse navbar-transparent">
       <ul class="nav navbar-nav menu">
         <li><a href="/">Map</a></li>
         <li><a href="/about">About</a></li>

--- a/strabo/templates/public/header.html
+++ b/strabo/templates/public/header.html
@@ -1,14 +1,12 @@
 <link href="{{PATH_TO_PUBLIC_STYLES}}{{HEADER_CSS}}" rel="stylesheet" >
 
-<!-- Navigation -->
-<nav class="navbar navbar-fixed-top" role="navigation"> <!--bootstrap navbar--> <!--navbar-fixed-top stays at the top of the page, navbar-inverse??? I deleted it and stuff changed lol-->
-  <div class="container-fluid"> <!--container is a fixed width container, container-fluid spans the width of your viewport. Haley had container, I'm doing container-fluid because it seems like what we want-->
+<nav class="navbar navbar-fixed-top" role="navigation">
+  <div class="container-fluid">
 
-    <div class="navbar-header"> <!--when the navbar is seen on mobile-->
+    <div class="navbar-header"> 
 
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
-        <!--icon bars for image-->
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>


### PR DESCRIPTION
I decided not to both with slide navigation (although that remains the name of the branch) and instead messed around with the opacity of the mobile nav, and underlined the text.

What do you two prefer in terms of readability?

<img width="320" alt="screen shot 2016-08-07 at 4 42 25 pm" src="https://cloud.githubusercontent.com/assets/17392296/17467376/8392a3c0-5cd2-11e6-98dc-b7f048780d1a.png">
<img width="316" alt="screen shot 2016-08-07 at 4 42 32 pm" src="https://cloud.githubusercontent.com/assets/17392296/17467375/8392b66c-5cd2-11e6-966e-33de58f80206.png">

Or:

<img width="332" alt="screen shot 2016-08-07 at 4 51 10 pm" src="https://cloud.githubusercontent.com/assets/17392296/17467378/839561a0-5cd2-11e6-89ee-fa7ac1ca6fb1.png">
<img width="334" alt="screen shot 2016-08-07 at 4 51 17 pm" src="https://cloud.githubusercontent.com/assets/17392296/17467377/8394b322-5cd2-11e6-9551-375a61a790e2.png">

Although right or left slide navigation would be nice, I think we have a functional Bootstrap responsive navigation already working so it makes more sense just to tinker with it.
