### PR TITLE
No drop shadow on IP images

### DIFF
--- a/strabo/static/public_styles/popup.css
+++ b/strabo/static/public_styles/popup.css
@@ -74,9 +74,8 @@ Then there is the #button-section, which floats above the other sections.
 .carousel-cell.is-selected img{
     /*highlighting around centered flickty image*/
     /* pattern:  _ _ blur spread color*/
-    /* box-shadow: 0 0 20px 20px rgba(0,0,0,0.6); */
     border-style: solid;
-    border-width: 0.3em;
+    border-width: 0.25em;
     border-color: #ebf5e4;
 }
 

--- a/strabo/static/public_styles/popup.css
+++ b/strabo/static/public_styles/popup.css
@@ -24,7 +24,7 @@ Then there is the #button-section, which floats above the other sections.
     left: 0;
     top: 0;
     bottom: 0;
-    background: rgba(0,0,0,0.7);
+    background: rgba(0,0,0,0.35);
     z-index: 100000; /* goes above leaflet link */
 }
 .popup-foreground {
@@ -34,10 +34,10 @@ Then there is the #button-section, which floats above the other sections.
     max-height: 800px;
     max-width: 700px;
     /*differentiates popup background slightly from normal background*/
-    background: rgba(0,0,0,0.2);
+    background: rgba(0,0,0,0.65);
     /* border around box on large screens
      * pattern:  _ _ blur spread color*/
-    box-shadow: 0 0 10px 10px rgba(0,0,0,0.4);
+    box-shadow: 0 0 10px 10px rgba(0,0,0,0.2);
     overflow: hidden;
 }
 
@@ -75,7 +75,11 @@ Then there is the #button-section, which floats above the other sections.
     /*highlighting around centered flickty image*/
     /* pattern:  _ _ blur spread color*/
     /* box-shadow: 0 0 20px 20px rgba(0,0,0,0.6); */
+    border-style: solid;
+    border-width: 0.3em;
+    border-color: #ebf5e4;
 }
+
 .img-description {
     color: #422C1E;
     font-family: 'Futura', 'Trebuchet MS', Arial, sans-serif;

--- a/strabo/static/public_styles/popup.css
+++ b/strabo/static/public_styles/popup.css
@@ -24,7 +24,7 @@ Then there is the #button-section, which floats above the other sections.
     left: 0;
     top: 0;
     bottom: 0;
-    background: rgba(0,0,0,0.5);
+    background: rgba(0,0,0,0.7);
     z-index: 100000; /* goes above leaflet link */
 }
 .popup-foreground {
@@ -74,7 +74,7 @@ Then there is the #button-section, which floats above the other sections.
 .carousel-cell.is-selected img{
     /*highlighting around centered flickty image*/
     /* pattern:  _ _ blur spread color*/
-    box-shadow: 0 0 20px 20px rgba(0,0,0,0.6);
+    /* box-shadow: 0 0 20px 20px rgba(0,0,0,0.6); */
 }
 .img-description {
     color: #422C1E;


### PR DESCRIPTION
I removed the drop shadow and replaced it with a thin 0.25em border. 

Here's how it looks: 
<img width="309" alt="screen shot 2016-08-16 at 12 22 38 pm" src="https://cloud.githubusercontent.com/assets/16883323/17712780/55f9bfc6-63ac-11e6-9c22-67559d8a6af5.png">
<img width="1269" alt="screen shot 2016-08-16 at 12 22 12 pm" src="https://cloud.githubusercontent.com/assets/16883323/17712781/55fd87c8-63ac-11e6-8129-e57fd55e2810.png">
